### PR TITLE
Update python_version 3.13 phase 1 and 2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,11 @@ repos:
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
+  - repo: https://github.com/phantomcyber/soar-app-linter
+    rev: 0.1.0
+    hooks:
+      - id: soar-app-linter
+        args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
     rev: 0.7.22
     hooks:
@@ -55,7 +60,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.0.4
+    rev: v2.0.9
     hooks:
       - id: build-docs
         language: python

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MASTER]
+ignore=.venv

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Mnemonic
 
-Publisher: Splunk \
-Connector Version: 2.0.8 \
-Product Vendor: Mnemonic \
-Product Name: Passive DNS \
+Publisher: Splunk <br>
+Connector Version: 2.0.8 <br>
+Product Vendor: Mnemonic <br>
+Product Name: Passive DNS <br>
 Minimum Product Version: 5.1.0
 
 This app integrates with the Mnemonic Passive DNS API to implement investigative actions
@@ -18,14 +18,14 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration \
+[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration <br>
 [lookup domain](#action-lookup-domain) - Check for the presence of a domain in a threat intelligence feed
 
 ## action: 'test connectivity'
 
 Validate the asset configuration for connectivity using supplied configuration
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -40,7 +40,7 @@ No Output
 
 Check for the presence of a domain in a threat intelligence feed
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters

--- a/mnemonic.json
+++ b/mnemonic.json
@@ -243,5 +243,11 @@
             },
             "versions": "EQ(*)"
         }
-    ]
+    ],
+    "pip39_dependencies": {
+        "wheel": []
+    },
+    "pip313_dependencies": {
+        "wheel": []
+    }
 }

--- a/mnemonic.json
+++ b/mnemonic.json
@@ -15,7 +15,7 @@
     "utctime_updated": "2025-04-14T21:15:02.105265Z",
     "package_name": "phantom_mnemonic",
     "min_phantom_version": "5.1.0",
-    "python_version": "3",
+    "python_version": "3.9, 3.13",
     "fips_compliant": true,
     "app_wizard_version": "1.0.0",
     "latest_tested_versions": [

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 * Resolved app issues related to Python 3.13 upgrade
 * Remove beautifulsoup4 from requirements.txt
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13 for phase 1 and 2
- Replace `.pre-commit-config.yaml` with latest template from dev-cicd-tools

[_Created by Sourcegraph batch change `grokas-splunk/python-versions-3.13-phase1and2`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/python-versions-3.13-phase1and2)