### PR TITLE
fix: escape Mnemonic widget values

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.15.22
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+    rev: v1.40.8
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -43,12 +43,12 @@ repos:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.136.0
+    rev: v1.165.0
     hooks:
       - id: semgrep
         additional_dependencies: ["setuptools==81.0.0"]
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.4
     hooks:
       - id: build-docs
         language: python

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2017-2025 Splunk Inc.
+   Copyright (c) 2017-2026 Splunk Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Splunk SOAR App: Mnemonic
-Copyright (c) 2017-2025 Splunk Inc.
+Copyright (c) 2017-2026 Splunk Inc.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2017-2025 Splunk Inc.
+# Copyright (c) 2017-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/display_lookup_domain.html
+++ b/display_lookup_domain.html
@@ -11,7 +11,7 @@
 {% block widget_content %}
   <!-- Main Start Block -->
   <!--File: display_lookup_domain.html
-Copyright (c) 2017-2025 Splunk Inc.
+Copyright (c) 2017-2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/display_lookup_domain.html
+++ b/display_lookup_domain.html
@@ -93,7 +93,7 @@ and limitations under the License.
             </td>
             <td>
               <a href="javascript:;"
-                 onclick="context_menu(this, [{'contains': ['{{ result.param.domain_contains }}'], 'value': '{{ result.param.domain }}' }], 0, {{ container.id }}, null, false);">
+                 onclick="context_menu(this, [{'contains': ['{{ result.param.domain_contains|escapejs }}'], 'value': '{{ result.param.domain|escapejs }}' }], 0, {{ container.id }}, null, false);">
                 {{ result.param.domain }}
                 &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
               </a>
@@ -154,14 +154,14 @@ and limitations under the License.
               <tr>
                 <td class="widget-td">
                   <a href="javascript:;"
-                     onclick="context_menu(this, [{'contains': ['domain'], 'value': '{{ curr_data.query }}' }], 0, {{ container.id }}, null, false);">
+                     onclick="context_menu(this, [{'contains': ['domain'], 'value': '{{ curr_data.query|escapejs }}' }], 0, {{ container.id }}, null, false);">
                     {{ curr_data.query }}
                     &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                   </a>
                 </td>
                 <td class="widget-td">
                   <a href="javascript:;"
-                     onclick="context_menu(this, [{'contains': ['{{ curr_data.answer_contains }}'], 'value': '{{ curr_data.answer }}' }], 0, {{ container.id }}, null, false);">
+                     onclick="context_menu(this, [{'contains': ['{{ curr_data.answer_contains|escapejs }}'], 'value': '{{ curr_data.answer|escapejs }}' }], 0, {{ container.id }}, null, false);">
                     {{ curr_data.answer }}
                     &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                   </a>

--- a/mnemonic.json
+++ b/mnemonic.json
@@ -10,7 +10,7 @@
     "product_name": "Passive DNS",
     "product_version_regex": ".*",
     "publisher": "Splunk",
-    "license": "Copyright (c) 2017-2025 Splunk Inc.",
+    "license": "Copyright (c) 2017-2026 Splunk Inc.",
     "app_version": "2.0.9",
     "utctime_updated": "2025-09-05T16:40:50.678857Z",
     "package_name": "phantom_mnemonic",

--- a/mnemonic_connector.py
+++ b/mnemonic_connector.py
@@ -1,6 +1,6 @@
 # File: mnemonic_connector.py
 #
-# Copyright (c) 2017-2025 Splunk Inc.
+# Copyright (c) 2017-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -149,7 +149,7 @@ class MnemonicConnector(BaseConnector):
         self.save_progress(f"Querying a domain to test connectivity to {self._base_url}/{self._domain} ")
 
         # make rest call
-        ret_val, response = self._make_rest_call(f"/{self._domain}", action_result, params={"limit": 1, "offset": 0})
+        ret_val, _response = self._make_rest_call(f"/{self._domain}", action_result, params={"limit": 1, "offset": 0})
 
         if phantom.is_fail(ret_val):
             # the call to the 3rd party device or service failed, action result should contain all the error details

--- a/mnemonic_consts.py
+++ b/mnemonic_consts.py
@@ -1,6 +1,6 @@
 # File: mnemonic_consts.py
 #
-# Copyright (c) 2017-2025 Splunk Inc.
+# Copyright (c) 2017-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mnemonic_view.py
+++ b/mnemonic_view.py
@@ -1,6 +1,6 @@
 # File: mnemonic_view.py
 #
-# Copyright (c) 2017-2025 Splunk Inc.
+# Copyright (c) 2017-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Escape dynamic JavaScript values in the domain lookup widget.


### PR DESCRIPTION
## Summary

- escape the requested domain and returned query/answer values before embedding them in inline JavaScript context menus
- refresh connector tooling and generated metadata

## Tracking

- PAPP-38252
- PSAAS-30740 (VULN-93467 / FS-1551)
- Parent epic: ESPM-5228

## Verification

- full `pre-commit run --all-files` passed
- `python3 -m compileall` passed
- no connector-local tests were added because this is a BaseConnector app

Written by Codex.